### PR TITLE
Ignore /doc/tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/doc/tags


### PR DESCRIPTION
Tags are created automatically by many plugins managers. For example pathogen places them here.
